### PR TITLE
Fix typo in cursors.sass which breaks build

### DIFF
--- a/sass/helpers/cursor/cursors.sass
+++ b/sass/helpers/cursor/cursors.sass
@@ -1,4 +1,4 @@
-$cursors: ('default', 'pointer' 'grab' 'help' 'wait' 'crosshair' 'not-allowed' 'zoom-in')
+$cursors: ('default' 'pointer' 'grab' 'help' 'wait' 'crosshair' 'not-allowed' 'zoom-in')
 
 @each $cursor in $cursors
   .has-cursor-#{$cursor}


### PR DESCRIPTION
The current version introduced a typo which generates the following code:

```css
has-cursor-pointer grab help wait crosshair not-allowed zoom-in {
  cursor: -webkit-grab !important;
  cursor: pointer -webkit-grab help wait crosshair not-allowed zoom-in !important;
  cursor: grab !important;
  cursor: pointer grab help wait crosshair not-allowed zoom-in !important;
}
```