### PR TITLE
Inconsistent indentation

### DIFF
--- a/sass/helpers/media-queries/sizing/_all.sass
+++ b/sass/helpers/media-queries/sizing/_all.sass
@@ -22,7 +22,7 @@
         @each $dimension in 'width' 'height'
           @each $modifier in 'max' 'min'
             +mq('has-#{$modifier}-#{$dimension}-#{$current}')
-               #{$modifier}-#{$dimension}: #{$current}px !important
+              #{$modifier}-#{$dimension}: #{$current}px !important
               
         $current: $current + $interval
     


### PR DESCRIPTION
15 spaces were used for indentation, but the rest of the document was indented using 2 spaces.