### PR TITLE
Fix copy and paste error

### DIFF
--- a/sass/helpers/spacing/margin-padding.sass
+++ b/sass/helpers/spacing/margin-padding.sass
@@ -28,11 +28,11 @@ $current: $range-start
       padding-#{$side}: #{$current}px !important
 
     @each $unit in $additional-units
-      .has-margin-#{$current}-#{$unit}
-        margin: #{$current + $unit} !important
+      .has-margin-#{$side}-#{$current}-#{$unit}
+        margin-#{$side}: #{$current + $unit} !important
 
-      .has-padding-#{$current}-#{$unit}
-        padding: #{$current + $unit}  !important
+      .has-padding-#{$side}-#{$current}-#{$unit}
+        padding-#{side}: #{$current + $unit}  !important
   
   $current: $current + $interval
 


### PR DESCRIPTION
`has-margin-top-5-em` and similar has-margin-`side`-`additional spacing unit` type classes did not work. This  MR makes sure the additional spacing unit rules are generated for each individual side.

Looking into the code it appears that the intention was to support this, but it was never completed/tested. Oops.